### PR TITLE
submit cloudwatch more than 20 metrics

### DIFF
--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -228,10 +228,20 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
       end # data.each
 
       begin
-        @cw.put_metric_data(
-            :namespace => namespace,
-            :metric_data => metric_data
-        )
+        while (metric_data.length > 20)
+          new_metric_data = metric_data.shift(20)
+          @cw.put_metric_data(
+              :namespace => namespace,
+              :metric_data => new_metric_data
+          )
+          @logger.info("metric bigger than 20, send by own function")
+        end
+        if (metric_data.length > 0)
+          @cw.put_metric_data(
+              :namespace => namespace,
+              :metric_data => metric_data
+          )
+        end
         @logger.info("Sent data to AWS CloudWatch OK", :namespace => namespace, :metric_data => metric_data)
       rescue Exception => e
         @logger.warn("Failed to send to AWS CloudWatch", :exception => e, :namespace => namespace, :metric_data => metric_data)


### PR DESCRIPTION
cloudwatch receive max 20 metrics by default, 
add a decision when metrics more than 20, send multiple cloudwatch request to fix problem, 
when need to submit more than 20 metrics at logstash.
