### PR TITLE
Migrate this plugin to the `AWS-SDK` v2 api

### DIFF
--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -61,8 +61,8 @@ require "logstash/plugin_mixins/aws_config"
 # and the specific of API endpoint this output uses,
 # http://docs.amazonwebservices.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html[PutMetricData]
 class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
-  include LogStash::PluginMixins::AwsConfig
-
+  include LogStash::PluginMixins::AwsConfig::V2
+  
   config_name "cloudwatch"
 
   # Constants
@@ -155,19 +155,12 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
   config :field_dimensions, :validate => :string, :default => "CW_dimensions"
 
   public
-  def aws_service_endpoint(region)
-    return {
-        :cloud_watch_endpoint => "monitoring.#{region}.amazonaws.com"
-    }
-  end
-
-  public
   def register
     require "thread"
     require "rufus/scheduler"
-    require "aws"
+    require "aws-sdk"
 
-    @cw = AWS::CloudWatch.new(aws_options_hash)
+    @cw = Aws::CloudWatch::Client.new(aws_options_hash)
 
     @event_queue = SizedQueue.new(@queue_size)
     @scheduler = Rufus::Scheduler.new

--- a/logstash-output-cloudwatch.gemspec
+++ b/logstash-output-cloudwatch.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
   s.add_runtime_dependency 'logstash-mixin-aws', '>= 1.0.0'
   s.add_runtime_dependency 'rufus-scheduler', [ '~> 3.0.9' ]
-  s.add_runtime_dependency 'aws-sdk'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This is part of the effort of migrating all the plugins to the `AWS-SDK` in https://github.com/logstash-plugins/logstash-mixin-aws/pull/13
