### PR TITLE
Fix get timestamp from event

### DIFF
--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -303,7 +303,7 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
         METRIC => (fmetric ? fmetric : event.sprintf(@metricname)),
         DIMENSIONS => dims,
         UNIT => unit,
-        TIMESTAMP => event.sprintf("%{+YYYY-MM-dd'T'HH:mm:00Z}")
+        TIMESTAMP => event.get('timestamp')
     }
 
     if (!aggregates[namespace][aggregate_key])


### PR DESCRIPTION
Seems to be an issue in the way is parsing the timestamp for the events that's generating some errors when trying to push them to cloudwatch.

just a simple fix to use the event.get method to set the timestamp from the `@timestamp` of the event  to be pushed to cloudwatch