### PR TITLE
 Remove of unusefull SHUTDOWN event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+- Fix: dropped usage of SHUTDOWN event deprecated since Logstash 5.0 [#18](https://github.com/logstash-plugins/logstash-output-cloudwatch/pull/18)
+
 ## 3.0.8
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -172,15 +172,6 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
-
-    if event == LogStash::SHUTDOWN
-      job.trigger()
-      job.unschedule()
-      @logger.info("CloudWatch aggregator thread shutdown.")
-      return
-    end
-
     return unless (event.get(@field_metricname) || @metricname)
 
     if (@event_queue.length >= @event_queue.max)

--- a/logstash-output-cloudwatch.gemspec
+++ b/logstash-output-cloudwatch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-cloudwatch'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Aggregates and sends metric data to AWS CloudWatch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
In Logstash 8.0 the SHUTDOWN event is removed and was deprecated/not used since Logstash 5.0, remove it.
